### PR TITLE
rename the library name for bpftime

### DIFF
--- a/.github/workflows/bpf_conformance.yml
+++ b/.github/workflows/bpf_conformance.yml
@@ -63,6 +63,7 @@ jobs:
         # Upload entire repository
         path: '.'
   deploy:
+    if: github.event_name == 'push'
     # Add a dependency to the build job
     needs: build
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ CMakeFiles
 _deps
 cmake_install.cmake
 compile_commands.json
-libbpftime_llvm_jit_vm.a
+libllvmbpf_vm.a
 test.o
 test.bin
 *.ll

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,14 +28,14 @@ function(bpftime_add_library target)
     bpftime_setup_target(${target})
 endfunction()
 
-bpftime_add_library(bpftime_llvm_jit_vm
+bpftime_add_library(llvmbpf_vm
     src/llvm_jit_context.cpp
     src/compiler.cpp
     src/compiler_utils.cpp
     src/vm.cpp
 )
 
-set_target_properties(bpftime_llvm_jit_vm PROPERTIES ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/../")
+set_target_properties(llvmbpf_vm PROPERTIES ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/../")
 
 find_package(LLVM REQUIRED CONFIG)
 
@@ -98,11 +98,11 @@ endif()
 message(STATUS "LLVM_LIBS=${LLVM_LIBS}")
 find_package(Boost REQUIRED)
 
-target_link_libraries(bpftime_llvm_jit_vm PUBLIC ${LLVM_LIBS} PRIVATE spdlog::spdlog)
-    target_include_directories(bpftime_llvm_jit_vm 
+target_link_libraries(llvmbpf_vm PUBLIC ${LLVM_LIBS} PRIVATE spdlog::spdlog)
+    target_include_directories(llvmbpf_vm 
     PUBLIC ${LLVM_INCLUDE_DIRS} ${SPDLOG_INCLUDE} ${Boost_INCLUDE} ../include include #LLVM jit also used these headers
 )
-add_dependencies(bpftime_llvm_jit_vm spdlog::spdlog)
+add_dependencies(llvmbpf_vm spdlog::spdlog)
 
 if(BPFTIME_ENABLE_UNIT_TESTING)
   message(STATUS "Build unit tests for the project. Tests should always be found in the test folder\n")

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ See [example](example/main.cpp) of how to use the library as a vm:
 void run_ebpf_prog(const void *code, size_t code_len)
 {
     uint64_t res = 0;
-    bpftime_llvm_jit_vm vm;
+    llvmbpf_vm vm;
 
     res = vm.load_code(code, code_len);
     if (res) {

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -37,9 +37,9 @@ add_dependencies(bpftime-vm-cli libbpf_project)
 
 include_directories(${LIBBPF_INCLUDE_DIRS})
 
-add_dependencies(bpftime-vm-cli spdlog::spdlog bpftime_llvm_jit_vm)
+add_dependencies(bpftime-vm-cli spdlog::spdlog llvmbpf_vm)
 target_link_libraries(bpftime-vm-cli 
-            PRIVATE spdlog::spdlog bpftime_llvm_jit_vm 
+            PRIVATE spdlog::spdlog llvmbpf_vm 
             ${LIBBPF_LIBRARIES} 
             elf 
             z

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -76,7 +76,7 @@ static int build_ebpf_program(const std::string &ebpf_elf,
 		const char *name = bpf_program__name(prog);
 		if (!emit_llvm)
 			SPDLOG_INFO("Processing program {}", name);
-		bpftime_llvm_jit_vm vm;
+		llvmbpf_vm vm;
 
 		if (vm.load_code((const void *)bpf_program__insns(prog),
 				 (uint32_t)bpf_program__insn_cnt(prog) * 8) <
@@ -125,7 +125,7 @@ static int run_ebpf_program(const std::filesystem::path &elf,
 
 	file.close();
 
-	bpftime_llvm_jit_vm vm;
+	llvmbpf_vm vm;
 	auto func = vm.load_aot_object(file_buffer);
 	if (!func) {
 		SPDLOG_CRITICAL("Failed to load AOT object from ELF file: {}",

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -2,6 +2,6 @@ bpftime_add_executable(vm-llvm-example
     ./main.cpp
 )
 
-add_dependencies(vm-llvm-example bpftime_llvm_jit_vm spdlog::spdlog)
-target_link_libraries(vm-llvm-example bpftime_llvm_jit_vm)
+add_dependencies(vm-llvm-example llvmbpf_vm spdlog::spdlog)
+target_link_libraries(vm-llvm-example llvmbpf_vm)
 

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -74,7 +74,7 @@ const unsigned char bpf_function_call_print[] =
 void run_ebpf_prog(const void *code, size_t code_len)
 {
 	uint64_t res = 0;
-	bpftime_llvm_jit_vm vm;
+	llvmbpf_vm vm;
 	printf("running ebpf prog, code len: %zd\n", code_len);
 
 	res = vm.load_code(code, code_len);

--- a/include/llvmbpf.hpp
+++ b/include/llvmbpf.hpp
@@ -21,10 +21,10 @@ class llvm_bpf_jit_context;
 // The JITed function can be called with the memory and memory length directly.
 using precompiled_ebpf_function = uint64_t (*)(void *mem, size_t mem_len);
 
-class bpftime_llvm_jit_vm {
+class llvmbpf_vm {
     public:
-	bpftime_llvm_jit_vm();
-	~bpftime_llvm_jit_vm();  // Destructor declared
+	llvmbpf_vm();
+	~llvmbpf_vm();  // Destructor declared
 	std::string get_error_message();
 	// register external function, e.g. helper functions for eBPF
 	int register_external_function(size_t index, const std::string &name,

--- a/src/llvm_jit_context.cpp
+++ b/src/llvm_jit_context.cpp
@@ -233,7 +233,7 @@ extern "C" void __aeabi_unwind_cpp_pr1();
 
 static int llvm_initialized = 0;
 
-llvm_bpf_jit_context::llvm_bpf_jit_context(bpftime_llvm_jit_vm &vm) : vm(vm)
+llvm_bpf_jit_context::llvm_bpf_jit_context(llvmbpf_vm &vm) : vm(vm)
 {
 	using namespace llvm;
 	int zero = 0;

--- a/src/llvm_jit_context.hpp
+++ b/src/llvm_jit_context.hpp
@@ -18,7 +18,7 @@
 namespace bpftime
 {
 
-class bpftime_llvm_jit_vm;
+class llvmbpf_vm;
 
 const static char *LDDW_HELPER_MAP_BY_FD = "__lddw_helper_map_by_fd";
 const static char *LDDW_HELPER_MAP_BY_IDX = "__lddw_helper_map_by_idx";
@@ -38,7 +38,7 @@ const static char *LDDW_HELPER_CODE_ADDR = "__lddw_helper_code_addr";
 #endif
 
 class llvm_bpf_jit_context {
-	bpftime_llvm_jit_vm &vm;
+	llvmbpf_vm &vm;
 	std::optional<std::unique_ptr<llvm::orc::LLJIT> > jit;
 	std::unique_ptr<pthread_spinlock_t> compiling;
 	llvm::Expected<llvm::orc::ThreadSafeModule>
@@ -57,7 +57,7 @@ class llvm_bpf_jit_context {
 
     public:
 	void do_jit_compile();
-	llvm_bpf_jit_context(bpftime_llvm_jit_vm &vm);
+	llvm_bpf_jit_context(llvmbpf_vm &vm);
 	virtual ~llvm_bpf_jit_context();
 	precompiled_ebpf_function compile();
 	precompiled_ebpf_function get_entry_address();

--- a/src/vm.cpp
+++ b/src/vm.cpp
@@ -7,20 +7,20 @@
 
 using namespace bpftime;
 
-bpftime_llvm_jit_vm::bpftime_llvm_jit_vm()
+llvmbpf_vm::llvmbpf_vm()
 	: ext_funcs(MAX_EXT_FUNCS),
 	  jit_ctx(std::make_unique<bpftime::llvm_bpf_jit_context>(*this))
 {
 }
 
-bpftime_llvm_jit_vm::~bpftime_llvm_jit_vm() = default;
+llvmbpf_vm::~llvmbpf_vm() = default;
 
-std::string bpftime_llvm_jit_vm::get_error_message()
+std::string llvmbpf_vm::get_error_message()
 {
 	return error_msg;
 }
 
-int bpftime_llvm_jit_vm::register_external_function(size_t index,
+int llvmbpf_vm::register_external_function(size_t index,
 						    const std::string &name,
 						    void *fn)
 {
@@ -36,7 +36,7 @@ int bpftime_llvm_jit_vm::register_external_function(size_t index,
 	return 0;
 }
 
-int bpftime_llvm_jit_vm::load_code(const void *code, size_t code_len)
+int llvmbpf_vm::load_code(const void *code, size_t code_len)
 {
 	if (code_len % 8 != 0) {
 		error_msg = "Code len must be a multiple of 8";
@@ -47,12 +47,12 @@ int bpftime_llvm_jit_vm::load_code(const void *code, size_t code_len)
 	return 0;
 }
 
-void bpftime_llvm_jit_vm::unload_code()
+void llvmbpf_vm::unload_code()
 {
 	instructions.clear();
 }
 
-int bpftime_llvm_jit_vm::exec(void *mem, size_t mem_len,
+int llvmbpf_vm::exec(void *mem, size_t mem_len,
 			      uint64_t &bpf_return_value)
 {
 	if (jitted_function) {
@@ -76,14 +76,14 @@ int bpftime_llvm_jit_vm::exec(void *mem, size_t mem_len,
 	return exec(mem, mem_len, bpf_return_value);
 }
 
-std::optional<bpftime::precompiled_ebpf_function> bpftime_llvm_jit_vm::compile()
+std::optional<bpftime::precompiled_ebpf_function> llvmbpf_vm::compile()
 {
 	auto func = jit_ctx->compile();
 	jitted_function = func;
 	return func;
 }
 
-void bpftime_llvm_jit_vm::set_lddw_helpers(uint64_t (*map_by_fd)(uint32_t),
+void llvmbpf_vm::set_lddw_helpers(uint64_t (*map_by_fd)(uint32_t),
 					   uint64_t (*map_by_idx)(uint32_t),
 					   uint64_t (*map_val)(uint64_t),
 					   uint64_t (*var_addr)(uint32_t),
@@ -96,13 +96,13 @@ void bpftime_llvm_jit_vm::set_lddw_helpers(uint64_t (*map_by_fd)(uint32_t),
 	this->code_addr = code_addr;
 }
 
-std::vector<uint8_t> bpftime_llvm_jit_vm::do_aot_compile(bool print_ir)
+std::vector<uint8_t> llvmbpf_vm::do_aot_compile(bool print_ir)
 {
 	return this->jit_ctx->do_aot_compile(print_ir);
 }
 
 std::optional<bpftime::precompiled_ebpf_function>
-bpftime_llvm_jit_vm::load_aot_object(const std::vector<uint8_t> &object)
+llvmbpf_vm::load_aot_object(const std::vector<uint8_t> &object)
 {
 	if (jitted_function) {
 		error_msg = "Already compiled";

--- a/test/bpf_conformance_runner/CMakeLists.txt
+++ b/test/bpf_conformance_runner/CMakeLists.txt
@@ -2,7 +2,7 @@ add_executable(bpftime_vm_bpf_conformance_runner
     main-bpf-conformance.cpp
 )
 
-add_dependencies(bpftime_vm_bpf_conformance_runner bpftime_llvm_jit_vm)
-target_link_libraries(bpftime_vm_bpf_conformance_runner bpftime_llvm_jit_vm)
+add_dependencies(bpftime_vm_bpf_conformance_runner llvmbpf_vm)
+target_link_libraries(bpftime_vm_bpf_conformance_runner llvmbpf_vm)
 
 set_target_properties(bpftime_vm_bpf_conformance_runner PROPERTIES CXX_STANDARD 20)

--- a/test/bpf_conformance_runner/main-bpf-conformance.cpp
+++ b/test/bpf_conformance_runner/main-bpf-conformance.cpp
@@ -103,7 +103,7 @@ int main(int argc, char **argv)
 	std::string log;
 
 	int err;
-	auto vm = bpftime_llvm_jit_vm();
+	auto vm = llvmbpf_vm();
 	err = vm.load_code(&program[0], program.size() * sizeof(ebpf_inst));
 	if (err < 0) {
 		std::cerr << "Error: " << vm.get_error_message() << std::endl;

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -16,7 +16,7 @@ set(TEST_SOURCES
 
 add_executable(llvm_jit_tests ${TEST_SOURCES})
 set_property(TARGET llvm_jit_tests PROPERTY CXX_STANDARD 20)
-add_dependencies(llvm_jit_tests bpftime_llvm_jit_vm)
-target_link_libraries(llvm_jit_tests PRIVATE bpftime_llvm_jit_vm Catch2::Catch2WithMain ${LIBBPF_LIBRARIES})
+add_dependencies(llvm_jit_tests llvmbpf_vm)
+target_link_libraries(llvm_jit_tests PRIVATE llvmbpf_vm Catch2::Catch2WithMain ${LIBBPF_LIBRARIES})
 target_include_directories(llvm_jit_tests PRIVATE ${Catch2_INCLUDE} ${CMAKE_CURRENT_SOURCE_DIR}/../include ${CMAKE_CURRENT_SOURCE_DIR}/../src ${LIBBPF_INCLUDE_DIRS} ${LIBBPF_INCLUDE_DIRS}/uapi)
 add_test(NAME llvm_jit_tests COMMAND llvm_jit_tests)

--- a/test/unit-test/llvm-aot.cpp
+++ b/test/unit-test/llvm-aot.cpp
@@ -12,7 +12,7 @@ extern "C" uint64_t add_func(uint64_t a, uint64_t b, uint64_t, uint64_t,
 
 TEST_CASE("Test aot compilation")
 {
-	bpftime::bpftime_llvm_jit_vm vm;
+	bpftime::llvmbpf_vm vm;
 	REQUIRE(vm.register_external_function(3, "add", (void *)add_func) == 0);
 	REQUIRE(vm.load_code((const void *)bpf_function_call_add,
 			     sizeof(bpf_function_call_add) - 1) == 0);


### PR DESCRIPTION
<!--# Pull Request Template-->

## Description

Rename `bpftime_llvm_jit_vm` to `llvmbpf_vm` so it's better for a standalone library