### PR TITLE
fix: build dependency issue

### DIFF
--- a/.github/workflows/bpf_conformance.yml
+++ b/.github/workflows/bpf_conformance.yml
@@ -36,16 +36,10 @@ jobs:
       with:
         python-version: '3.8'
 
-    
-    - name: Install Ninja (Ubuntu)
-      if: ${{matrix.container == 'ubuntu-2204'}}
-      run:
-        apt install ninja-build
-    
     - name: build
       run: 
            |
-          cmake -B build -DCMAKE_BUILD_TYPE=Debug -DBPFTIME_ENABLE_UNIT_TESTING=1 -G Ninja
+          cmake -B build -DCMAKE_BUILD_TYPE=Debug -DBPFTIME_ENABLE_UNIT_TESTING=1
           cmake --build build --target all -j
 
     - name: get bpf_conformance

--- a/.github/workflows/bpf_conformance.yml
+++ b/.github/workflows/bpf_conformance.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         path: ${{ github.workspace }}/${{ env.INSTALL_LOCATION }}
         key: ${{ runner.os }}-dependencies
-
+    
     - uses: actions/checkout@v2
       with:
         submodules: 'recursive'
@@ -36,10 +36,16 @@ jobs:
       with:
         python-version: '3.8'
 
+    
+    - name: Install Ninja (Ubuntu)
+      if: ${{matrix.container == 'ubuntu-22.04'}}
+      run:
+        apt install ninja-build
+    
     - name: build
       run: 
            |
-          cmake -B build -DCMAKE_BUILD_TYPE=Debug -DBPFTIME_ENABLE_UNIT_TESTING=1
+          cmake -B build -DCMAKE_BUILD_TYPE=Debug -DBPFTIME_ENABLE_UNIT_TESTING=1 -G Ninja
           cmake --build build --target all -j
 
     - name: get bpf_conformance

--- a/.github/workflows/bpf_conformance.yml
+++ b/.github/workflows/bpf_conformance.yml
@@ -38,7 +38,7 @@ jobs:
 
     
     - name: Install Ninja (Ubuntu)
-      if: ${{matrix.container == 'ubuntu-22.04'}}
+      if: ${{matrix.container == 'ubuntu-2204'}}
       run:
         apt install ninja-build
     

--- a/.github/workflows/test-aot-cli.yml
+++ b/.github/workflows/test-aot-cli.yml
@@ -23,10 +23,21 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: 'recursive'
+    
+    - name: Install Ninja (Ubuntu)
+      if: ${{matrix.container == 'ubuntu-22.04'}}
+      run:
+        apt install ninja-build
 
+    - name: Install Ninja (Fedora)
+      if: ${{matrix.container == 'fedora-39'}}
+      run:
+        dnf install ninja-build
+        
+    
     - name: Build and install everything
       run: |
-          cmake -B build -DCMAKE_BUILD_TYPE=Debug -DBPFTIME_ENABLE_UNIT_TESTING=1 -DBUILD_LLVM_AOT_CLI=1
+          cmake -B build -DCMAKE_BUILD_TYPE=Debug -DBPFTIME_ENABLE_UNIT_TESTING=1 -DBUILD_LLVM_AOT_CLI=1 -G Ninja
           cmake --build build --target all -j
     - name: Do compilation & run
       run: |

--- a/.github/workflows/test-aot-cli.yml
+++ b/.github/workflows/test-aot-cli.yml
@@ -25,7 +25,7 @@ jobs:
         submodules: 'recursive'
     
     - name: Install Ninja (Ubuntu)
-      if: ${{matrix.container == 'ubuntu-22.04'}}
+      if: ${{matrix.container == 'ubuntu-2204'}}
       run:
         apt install ninja-build
 

--- a/.github/workflows/test-aot-cli.yml
+++ b/.github/workflows/test-aot-cli.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Install Ninja (Fedora)
       if: ${{matrix.container == 'fedora-39'}}
       run:
-        dnf install ninja-build
+        dnf install -y ninja-build
         
     
     - name: Build and install everything

--- a/.github/workflows/test-vm.yml
+++ b/.github/workflows/test-vm.yml
@@ -33,7 +33,7 @@ jobs:
         submodules: 'recursive'
 
     - name: Install Ninja (Ubuntu)
-      if: ${{matrix.container == 'ubuntu-22.04'}}
+      if: ${{matrix.container == 'ubuntu-2204'}}
       run:
         apt install ninja-build
 

--- a/.github/workflows/test-vm.yml
+++ b/.github/workflows/test-vm.yml
@@ -32,6 +32,17 @@ jobs:
       with:
         submodules: 'recursive'
 
+    - name: Install Ninja (Ubuntu)
+      if: ${{matrix.container == 'ubuntu-22.04'}}
+      run:
+        apt install ninja-build
+
+    - name: Install Ninja (Fedora)
+      if: ${{matrix.container == 'fedora-39'}}
+      run:
+        dnf install ninja-build
+        
+    
     - uses: actions/setup-python@v4
       if: startsWith(matrix.container,'ubuntu')
       with:
@@ -40,7 +51,7 @@ jobs:
     - name: build
       run: 
            |
-          cmake -B build -DCMAKE_BUILD_TYPE=Debug -DBPFTIME_ENABLE_UNIT_TESTING=1
+          cmake -B build -DCMAKE_BUILD_TYPE=Debug -DBPFTIME_ENABLE_UNIT_TESTING=1 -G Ninja
           cmake --build build --target all -j
 
     - name: run testsuit x86

--- a/.github/workflows/test-vm.yml
+++ b/.github/workflows/test-vm.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Install Ninja (Fedora)
       if: ${{matrix.container == 'fedora-39'}}
       run:
-        dnf install ninja-build
+        dnf install -y ninja-build
         
     
     - uses: actions/setup-python@v4

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -25,7 +25,7 @@ jobs:
         submodules: 'recursive'
 
     - name: Install Ninja (Ubuntu)
-      if: ${{matrix.container == 'ubuntu-22.04'}}
+      if: ${{matrix.container == 'ubuntu-2204'}}
       run:
         apt install ninja-build
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Install Ninja (Fedora)
       if: ${{matrix.container == 'fedora-39'}}
       run:
-        dnf install ninja-build
+        dnf install -y ninja-build
         
   
     - name: build

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -24,10 +24,21 @@ jobs:
       with:
         submodules: 'recursive'
 
+    - name: Install Ninja (Ubuntu)
+      if: ${{matrix.container == 'ubuntu-22.04'}}
+      run:
+        apt install ninja-build
+
+    - name: Install Ninja (Fedora)
+      if: ${{matrix.container == 'fedora-39'}}
+      run:
+        dnf install ninja-build
+        
+  
     - name: build
       run: 
            |
-          cmake -B build -DCMAKE_BUILD_TYPE=Debug -DBPFTIME_ENABLE_UNIT_TESTING=1
+          cmake -B build -DCMAKE_BUILD_TYPE=Debug -DBPFTIME_ENABLE_UNIT_TESTING=1 -G Ninja
           cmake --build build --target all -j
 
     - name: Run example
@@ -40,6 +51,6 @@ jobs:
 
     - name: build llvm JIT/AOT release as a standalone library
       run: |
-        cmake -B build -DCMAKE_BUILD_TYPE=Release &&\
+        cmake -B build -DCMAKE_BUILD_TYPE=Release -G Ninja &&\
         cmake --build build --target all -j
    

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-
+cmake_policy(SET CMP0079 NEW)
 project(
     "llvm-bpf-jit"
     LANGUAGES C CXX

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set_target_properties(llvmbpf_vm PROPERTIES ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_CU
 
 find_package(LLVM REQUIRED CONFIG)
 
-if (${LLVM_PACKAGE_VERSION} VERSION_LESS 15)
+if(${LLVM_PACKAGE_VERSION} VERSION_LESS 15)
     message(FATAL_ERROR "LLVM version must be >=15")
 endif()
 
@@ -62,13 +62,15 @@ include(FetchContent)
 
 if(NOT DEFINED SPDLOG_INCLUDE)
     message(INFO " Adding spdlog seperately..")
+
     # spdlog
     # Fetch spdlog
     FetchContent_Declare(
-    spdlog
-    GIT_REPOSITORY https://github.com/gabime/spdlog.git
-    GIT_TAG v1.14.1 # Specify the version you want to use
+        spdlog
+        GIT_REPOSITORY https://github.com/gabime/spdlog.git
+        GIT_TAG v1.14.1 # Specify the version you want to use
     )
+
     # Make the spdlog target available
     FetchContent_MakeAvailable(spdlog)
 endif()
@@ -82,30 +84,31 @@ else()
     if(${BUILD_LLVM_AOT_CLI})
         add_subdirectory(cli)
     endif()
+
     if(${BPFTIME_ENABLE_UNIT_TESTING})
-      message(INFO " Adding Catch2 seperately..")
-       FetchContent_Declare(
-        catch
-        GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-        GIT_TAG v3.4.0 # Specify the version you want to use
-      )
-      
-      # Make the Catch2 target available
-      FetchContent_MakeAvailable(catch)
+        message(STATUS " Adding Catch2 seperately..")
+        FetchContent_Declare(
+            catch
+            GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+            GIT_TAG v3.4.0 # Specify the version you want to use
+        )
+
+        # Make the Catch2 target available
+        FetchContent_MakeAvailable(catch)
     endif()
 endif()
 
 message(STATUS "LLVM_LIBS=${LLVM_LIBS}")
 
 target_link_libraries(llvmbpf_vm PUBLIC ${LLVM_LIBS} PRIVATE spdlog::spdlog)
-    target_include_directories(llvmbpf_vm 
-    PUBLIC ${LLVM_INCLUDE_DIRS} ${SPDLOG_INCLUDE} ${Boost_INCLUDE} ../include include #LLVM jit also used these headers
+target_include_directories(llvmbpf_vm
+    PUBLIC ${LLVM_INCLUDE_DIRS} ${SPDLOG_INCLUDE} ${Boost_INCLUDE} ../include include # LLVM jit also used these headers
 )
 add_dependencies(llvmbpf_vm spdlog::spdlog)
 
 if(BPFTIME_ENABLE_UNIT_TESTING)
-  message(STATUS "Build unit tests for the project. Tests should always be found in the test folder\n")
-  add_subdirectory(test)
+    message(STATUS "Build unit tests for the project. Tests should always be found in the test folder\n")
+    add_subdirectory(test)
 endif()
 
 add_subdirectory(example)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,16 +85,16 @@ else()
         add_subdirectory(cli)
     endif()
 
-    if(${BPFTIME_ENABLE_UNIT_TESTING})
-        message(STATUS " Adding Catch2 seperately..")
+    if(${BPFTIME_ENABLE_UNIT_TESTING} AND NOT DEFINED Catch2_INCLUDE)
+        message(STATUS "Adding Catch2 seperately..")
         FetchContent_Declare(
-            catch
+            Catch2
             GIT_REPOSITORY https://github.com/catchorg/Catch2.git
             GIT_TAG v3.4.0 # Specify the version you want to use
         )
 
         # Make the Catch2 target available
-        FetchContent_MakeAvailable(catch)
+        FetchContent_MakeAvailable(Catch2)
     endif()
 endif()
 

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -15,29 +15,28 @@ target_include_directories(bpftime-vm-cli
     ${LIBBPF_INCLUDE_DIRS}
 )
 
+set(LIBBPF_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/libbpf_project)
+
 include(ExternalProject)
 ExternalProject_Add(
     libbpf_project
-    PREFIX ${CMAKE_BINARY_DIR}/libbpf
     GIT_REPOSITORY https://github.com/libbpf/libbpf.git
     GIT_TAG v1.2.0 # Replace with the version you need
     CONFIGURE_COMMAND ""
     BUILD_COMMAND make -C src -j
     BUILD_IN_SOURCE TRUE
     INSTALL_COMMAND ""
-    BUILD_BYPRODUCTS ${CMAKE_BINARY_DIR}/libbpf/src/libbpf.a
+    BUILD_BYPRODUCTS ${LIBBPF_SOURCE_DIR}/src/libbpf.a
+    SOURCE_DIR ${LIBBPF_SOURCE_DIR}
 )
 
-ExternalProject_Get_Property(libbpf_project source_dir)
-set(LIBBPF_INCLUDE_DIRS ${source_dir}/src)
-set(LIBBPF_LIBRARIES ${source_dir}/src/libbpf.a)
-
+set(LIBBPF_INCLUDE_DIRS ${LIBBPF_SOURCE_DIR}/src)
+set(LIBBPF_LIBRARIES ${LIBBPF_SOURCE_DIR}/src/libbpf.a)
 # Ensure libbpf is built before your target
-add_dependencies(bpftime-vm-cli libbpf_project)
 
 include_directories(${LIBBPF_INCLUDE_DIRS})
 
-add_dependencies(bpftime-vm-cli spdlog::spdlog llvmbpf_vm)
+add_dependencies(bpftime-vm-cli spdlog::spdlog llvmbpf_vm libbpf_project)
 target_link_libraries(bpftime-vm-cli 
             PRIVATE spdlog::spdlog llvmbpf_vm 
             ${LIBBPF_LIBRARIES} 

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -1,11 +1,13 @@
 # Have to fetch Catch2
-Include(FetchContent)
-FetchContent_Declare(
-    Catch2
-    GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-    GIT_TAG v3.4.0
-)
-FetchContent_MakeAvailable(Catch2)
+if(${BPFTIME_ENABLE_UNIT_TESTING} AND NOT DEFINED Catch2_INCLUDE)
+    Include(FetchContent)
+    FetchContent_Declare(
+        Catch2
+        GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+        GIT_TAG v3.4.0
+    )
+    FetchContent_MakeAvailable(Catch2)
+endif()
 
 set(TEST_SOURCES
     llvm-aot.cpp

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -1,14 +1,11 @@
-
-if(${ENABLE_EBPF_VERIFIER})
-    Include(FetchContent)
-    FetchContent_Declare(
-        Catch2
-        GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-        GIT_TAG v3.4.0
-    )
-    FetchContent_MakeAvailable(Catch2)
-    # if not enable verifier, we will use the catch2 from submodule
-endif()
+# Have to fetch Catch2
+Include(FetchContent)
+FetchContent_Declare(
+    Catch2
+    GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+    GIT_TAG v3.4.0
+)
+FetchContent_MakeAvailable(Catch2)
 
 set(TEST_SOURCES
     llvm-aot.cpp


### PR DESCRIPTION
Originally there is an invalid build byproduct making build system failed to detect a necessary file for building bpftime-vm-cli 
![a](https://github.com/user-attachments/assets/098bfd36-d15c-4c21-846a-4dc9b186ff68)

This PR fixes it, and uses Ninja for all CIs so we can get a more strict dependency check