### PR TITLE
fix: Add extra check for Catch2 target definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,8 +85,8 @@ else()
         add_subdirectory(cli)
     endif()
 
-    if(${BPFTIME_ENABLE_UNIT_TESTING} AND NOT DEFINED Catch2_INCLUDE)
-        message(STATUS "Adding Catch2 seperately..")
+    if(${BPFTIME_ENABLE_UNIT_TESTING} AND NOT TARGET Catch2)
+        message(STATUS "Adding Catch2 by FetchContent at llvmbpf")
         FetchContent_Declare(
             Catch2
             GIT_REPOSITORY https://github.com/catchorg/Catch2.git

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Have to fetch Catch2
-if(${BPFTIME_ENABLE_UNIT_TESTING} AND NOT DEFINED Catch2_INCLUDE)
+if(${BPFTIME_ENABLE_UNIT_TESTING} AND NOT TARGET Catch2)
+    message(STATUS "Adding Catch2 by FetchContent at llvmbpf/test/unit-test")
     Include(FetchContent)
     FetchContent_Declare(
         Catch2


### PR DESCRIPTION
Some options (such as BPFTIME_ENABLE_VERIFIER) may cause llvmbpf and bpftime both to have Catch2 defined. This PR adds extra guard at the definition of Catch2 target to avoid redefinition