### PR TITLE
update: add `SPDLOG_ACTIVE_LEVEL` definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,14 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Debug")
 endif()
 
+if(NOT DEFINED SPDLOG_ACTIVE_LEVEL)
+  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    add_compile_definitions(SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE)
+  else()
+    add_compile_definitions(SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO)
+  endif()
+endif()
+
 function(bpftime_setup_target target)
     set_property(TARGET ${target} PROPERTY CXX_STANDARD 20)
     target_include_directories(${target}

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -144,7 +144,8 @@ Expected<ThreadSafeModule> llvm_bpf_jit_context::generateModule(
 	blockBegin[0] = true;
 	for (uint16_t i = 0; i < insts.size(); i++) {
 		auto curr = insts[i];
-		SPDLOG_TRACE("check pc {} opcode={} ", i, (uint16_t)curr.opcode);
+		SPDLOG_TRACE("check pc {} opcode={} ", i,
+			     (uint16_t)curr.opcode);
 		if (i > 0 && is_jmp(insts[i - 1])) {
 			blockBegin[i] = true;
 			SPDLOG_TRACE("mark {} block begin", i);
@@ -153,7 +154,8 @@ Expected<ThreadSafeModule> llvm_bpf_jit_context::generateModule(
 			SPDLOG_TRACE("mark {} block begin", i + curr.imm + 1);
 			blockBegin[i + curr.imm + 1] = true;
 		} else if (is_jmp(curr)) {
-			SPDLOG_TRACE("mark {} block begin", i + curr.off + 1);
+			SPDLOG_TRACE("mark {} block begin",
+				     i + curr.offset + 1);
 			blockBegin[i + curr.offset + 1] = true;
 		}
 	}


### PR DESCRIPTION
This PR updates CMakeLists and added definition of `SPDLOG_ACTIVE_LEVEL`, so compile errors in SPDLOG_ macros could be detected in CI.