### PR TITLE
remove duplicate, version dependent import

### DIFF
--- a/src/llvm_jit_context.cpp
+++ b/src/llvm_jit_context.cpp
@@ -150,7 +150,6 @@
 #include <llvm/ExecutionEngine/JITSymbol.h>
 #include <llvm/IR/LegacyPassManager.h>
 #include <llvm/Transforms/IPO.h>
-#include <llvm/Support/Host.h>
 #include <llvm/MC/TargetRegistry.h>
 #include <memory>
 #include <pthread.h>


### PR DESCRIPTION
llvm/Support/Host.h is deprecated as of version 16, and the header is correctly imported on line 31 only if
compiling on version 15 or less.

I've recently switched to llvm v18, where the header is removed, and so I'm unable to compile this project.
So the unconditional import should definitely be removed.


<!--# Pull Request Template-->

## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.-->

Removed unconditional deprecated, and nonexistant as of llvm v18 `llvm/Support/Host.h` import.
Import redundant, as it is conditionally included based off llvm versions above in the file.

I couldn't find any release notes stating this, but I have the [relevant commit](https://github.com/llvm/llvm-project/commit/f09cf34d00625e57dea5317a3ac0412c07292148) which deprecated the file (marked for llvm 16).
Browsing through the source code between releases, I found that as of v18, the header had been removed.

## Type of change

<!--Please delete options that are not relevant.-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

Compiling with `LLVM_VERSION_MAJOR = 18` before change: 

```bash
❯ cmake -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
  cmake --build build --target all -j
-- Could NOT find LibEdit (missing: LibEdit_INCLUDE_DIRS LibEdit_LIBRARIES)
-- Could NOT find CURL (missing: CURL_LIBRARY CURL_INCLUDE_DIR)
-- Checking LLVM_VERSION_MAJOR macro value...
-- LLVM_VERSION_MAJOR is: 18
INFO Adding spdlog seperately..
-- Build spdlog: 1.14.1
-- Build type: Debug
-- LLVM_LIBS=LLVMCore;LLVMOrcJIT;LLVMMCJIT;LLVMSupport;LLVMX86CodeGen;LLVMX86Desc;LLVMX86Info
-- Configuring done (0.8s)
-- Generating done (0.0s)
-- Build files have been written to: /home/kristo/stuff/fork-llvmbpf/build
[ 47%] Built target spdlog
[ 52%] Building CXX object CMakeFiles/llvmbpf_vm.dir/src/llvm_jit_context.cpp.o
/home/kristo/stuff/fork-llvmbpf/src/llvm_jit_context.cpp:153:10: fatal error: llvm/Support/Host.h: No such file or directory
  153 | #include <llvm/Support/Host.h>
      |          ^~~~~~~~~~~~~~~~~~~~~
compilation terminated.
gmake[2]: *** [CMakeFiles/llvmbpf_vm.dir/build.make:76: CMakeFiles/llvmbpf_vm.dir/src/llvm_jit_context.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:124: CMakeFiles/llvmbpf_vm.dir/all] Error 2
gmake: *** [Makefile:91: all] Error 2
```

Compiling with `LLVM_VERSION_MAJOR = 18` after change:

```bash
❯ cmake -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
  cmake --build build --target all -j
-- Could NOT find LibEdit (missing: LibEdit_INCLUDE_DIRS LibEdit_LIBRARIES)
-- Could NOT find CURL (missing: CURL_LIBRARY CURL_INCLUDE_DIR)
-- Checking LLVM_VERSION_MAJOR macro value...
-- LLVM_VERSION_MAJOR is: 18
INFO Adding spdlog seperately..
-- Build spdlog: 1.14.1
-- Build type: Debug
-- LLVM_LIBS=LLVMCore;LLVMOrcJIT;LLVMMCJIT;LLVMSupport;LLVMX86CodeGen;LLVMX86Desc;LLVMX86Info
-- Configuring done (0.8s)
-- Generating done (0.0s)
-- Build files have been written to: /home/kristo/stuff/fork-llvmbpf/build
[ 47%] Built target spdlog
[ 76%] Built target llvmbpf_vm
[ 88%] Built target vm-llvm-example
[100%] Built target maps-example
```

**Test Configuration**:

- Firmware version: 
- Hardware:
- Toolchain:
- SDK:

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
