### PR TITLE
Only define helper symbols to JITDylib once

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,9 +71,7 @@ endif()
 
 include(FetchContent)
 
-if(DEFINED USE_SYSTEM_SPDLOG)
-    find_package(spdlog CONFIG REQUIRED)
-elif(NOT DEFINED SPDLOG_INCLUDE)
+if(NOT DEFINED SPDLOG_INCLUDE)
     message(INFO " Adding spdlog seperately..")
 
     # spdlog

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,9 @@ endif()
 
 include(FetchContent)
 
-if(NOT DEFINED SPDLOG_INCLUDE)
+if(DEFINED USE_SYSTEM_SPDLOG)
+    find_package(spdlog CONFIG REQUIRED)
+elif(NOT DEFINED SPDLOG_INCLUDE)
     message(INFO " Adding spdlog seperately..")
 
     # spdlog
@@ -84,8 +86,6 @@ if(NOT DEFINED SPDLOG_INCLUDE)
 
     # Make the spdlog target available
     FetchContent_MakeAvailable(spdlog)
-else()
-    find_package(spdlog CONFIG REQUIRED)
 endif()
 
 # if BPFTIME_LLVM_JIT is set, then it's built in the bpftime project.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,8 @@ if(NOT DEFINED SPDLOG_INCLUDE)
 
     # Make the spdlog target available
     FetchContent_MakeAvailable(spdlog)
+else()
+    find_package(spdlog CONFIG REQUIRED)
 endif()
 
 # if BPFTIME_LLVM_JIT is set, then it's built in the bpftime project.

--- a/src/llvm_jit_context.cpp
+++ b/src/llvm_jit_context.cpp
@@ -208,7 +208,7 @@ static void optimizeModule(llvm::Module &M)
 	// Create the pass manager.
 	// This one corresponds to a typical -O2 optimization pipeline.
 	ModulePassManager MPM =
-		PB.buildPerModuleDefaultPipeline(OptimizationLevel::O0);
+		PB.buildPerModuleDefaultPipeline(OptimizationLevel::O3);
 
 	// Optimize the IR!
 	MPM.run(M, MAM);
@@ -463,8 +463,6 @@ llvm_bpf_jit_context::create_and_initialize_lljit_instance()
 		jit->getExecutionSession().intern("__aeabi_unwind_cpp_pr1"),
 		JITEvaluatedSymbol::fromPointer(__aeabi_unwind_cpp_pr1));
 #endif
-	auto define_extSymbols_err =
-		mainDylib.define(absoluteSymbols(extSymbols));
 	if (auto err = mainDylib.define(absoluteSymbols(extSymbols)); !err) {
 		SPDLOG_DEBUG("LLVM-JIT: failed to define external symbols");
 	}

--- a/src/llvm_jit_context.cpp
+++ b/src/llvm_jit_context.cpp
@@ -150,7 +150,7 @@
 #include <llvm/ExecutionEngine/JITSymbol.h>
 #include <llvm/IR/LegacyPassManager.h>
 #include <llvm/Transforms/IPO.h>
-#include <llvm/Support/Host.h>
+#include <llvm/TargetParser/Host.h>
 #include <llvm/MC/TargetRegistry.h>
 #include <memory>
 #include <pthread.h>
@@ -208,7 +208,7 @@ static void optimizeModule(llvm::Module &M)
 	// Create the pass manager.
 	// This one corresponds to a typical -O2 optimization pipeline.
 	ModulePassManager MPM =
-		PB.buildPerModuleDefaultPipeline(OptimizationLevel::O3);
+		PB.buildPerModuleDefaultPipeline(OptimizationLevel::O0);
 
 	// Optimize the IR!
 	MPM.run(M, MAM);


### PR DESCRIPTION
<!--# Pull Request Template-->

## Description

JITDylib in LLVM 20 gets angry at you if the same symbols are defined twice. Fix it by removing one of the `JITDylib.define()` calls for helper functions.

## Type of change

<!--Please delete options that are not relevant.-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

`maps-example` output before fix:
```
running ebpf prog, code len: 296
Program aborted due to an unhandled Error:
Duplicate definition of symbol '_bpf_helper_ext_0001'
[1]    21015 IOT instruction (core dumped)  ./maps-example
```

output after fix:
```
running ebpf prog, code len: 296
map_by_fd 5
map_by_fd 6
map_val 6
cntrs_array[0] = 0
bpf_map_lookup_elem 5

return value = 1
cntrs_array[0] = 1
bpf_map_lookup_elem 5

return value = 1
cntrs_array[0] = 2
bpf_map_lookup_elem 5

return value = 2
```

**Test Configuration**:

- Firmware version: Fedora 42, Ubuntu 24.10, and Yocto Linux
- Hardware: AMD Ryzen Mobile CPU, Intel server CPU, and Polarfire RISC-V SoC
- Toolchain: Clang 20
- SDK: N/A

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
