### PR TITLE
fix: an llvm build issue

### DIFF
--- a/src/llvm_jit_context.cpp
+++ b/src/llvm_jit_context.cpp
@@ -602,7 +602,7 @@ llvm_bpf_jit_context::generate_ptx(bool main_with_arguments,
 		optimizeModule(M);
 
 		llvm::legacy::PassManager passManager;
-#if LLVM_VERSION_MAJOR > 16
+#if LLVM_VERSION_MAJOR > 17
 		CodeGenFileType fileType = CodeGenFileType::AssemblyFile;
 #else
 		CodeGenFileType fileType = llvm::CGFT_AssemblyFile;

--- a/src/llvm_jit_context.cpp
+++ b/src/llvm_jit_context.cpp
@@ -602,7 +602,7 @@ llvm_bpf_jit_context::generate_ptx(bool main_with_arguments,
 		optimizeModule(M);
 
 		llvm::legacy::PassManager passManager;
-#if LLVM_VERSION_MAJOR > 15
+#if LLVM_VERSION_MAJOR > 16
 		CodeGenFileType fileType = CodeGenFileType::AssemblyFile;
 #else
 		CodeGenFileType fileType = llvm::CGFT_AssemblyFile;


### PR DESCRIPTION
```
#if LLVM_VERSION_MAJOR > 15
		CodeGenFileType fileType = CodeGenFileType::AssemblyFile;
#else
		CodeGenFileType fileType = llvm::CGFT_AssemblyFile;

#endif
```
should be replaced by 
```
#if LLVM_VERSION_MAJOR > 17
		CodeGenFileType fileType = CodeGenFileType::AssemblyFile;
#else
		CodeGenFileType fileType = llvm::CGFT_AssemblyFile;

#endif
```