### PR TITLE
Fix LLVM Triple and RTTI problems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,13 @@ endif()
 
 message(STATUS "LLVM_LIBS=${LLVM_LIBS}")
 
+# Match LLVM's RTTI setting to avoid unresolved typeinfo symbols when
+# linking against static LLVM builds compiled with -fno-rtti.
+if(DEFINED LLVM_ENABLE_RTTI AND NOT LLVM_ENABLE_RTTI)
+    message(STATUS "LLVM was built without RTTI; compiling llvmbpf_vm with -fno-rtti")
+    target_compile_options(llvmbpf_vm PRIVATE -fno-rtti)
+endif()
+
 target_link_libraries(llvmbpf_vm PRIVATE ${LLVM_LIBS} PRIVATE spdlog::spdlog)
 target_include_directories(llvmbpf_vm
     PRIVATE ${LLVM_INCLUDE_DIRS} ${SPDLOG_INCLUDE} ${Boost_INCLUDE} ../include include # LLVM jit also used these headers

--- a/src/llvm_jit_context.cpp
+++ b/src/llvm_jit_context.cpp
@@ -549,8 +549,11 @@ std::vector<uint8_t> llvm_bpf_jit_context::do_aot_compile(
 				       vm.disabled_passes_, vm.log_passes_);
 			auto targetMachine =
 				create_host_target_machine_or_throw(vm);
-			module.setTargetTriple(
-				targetMachine->getTargetTriple().str());
+			#if LLVM_VERSION_MAJOR >= 21
+				module.setTargetTriple(targetMachine->getTargetTriple());
+			#else
+				module.setTargetTriple(targetMachine->getTargetTriple().str());
+			#endif
 			module.setDataLayout(targetMachine->createDataLayout());
 			SmallVector<char, 0> objStream;
 			std::unique_ptr<raw_svector_ostream> BOS =


### PR DESCRIPTION
This pull request focuses on improving compatibility with different LLVM build configurations and versions. The main changes ensure that the project correctly handles LLVM's RTTI settings and adapts to differences in the LLVM API across versions.

Build configuration improvements:

* Updated `CMakeLists.txt` to detect if LLVM was built without RTTI and, if so, compile `llvmbpf_vm` with `-fno-rtti` to prevent unresolved typeinfo symbol errors when linking against static LLVM builds.

LLVM API compatibility:

* Modified `llvm_bpf_jit_context::do_aot_compile` in `src/llvm_jit_context.cpp` to set the module's target triple in a way that is compatible with both LLVM 21 and earlier versions, using conditional compilation to handle API differences.